### PR TITLE
Add root user to HAPI compose service

### DIFF
--- a/docker-compose-h2.yml
+++ b/docker-compose-h2.yml
@@ -2,6 +2,7 @@ services:
   hapi:
     image: hapiproject/hapi:v8.2.0-1
     container_name: hapi-fhir
+    user: "0:0"
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
- run the HAPI container as root using uid/gid `0:0`

## Testing
- `docker-compose -f docker-compose-h2.yml down` *(fails: connection refused)*
- `docker-compose -f docker-compose-h2.yml up -d` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6869686299e8832b8a7bb3ea4d5fc41c